### PR TITLE
Bug/verify unsigning

### DIFF
--- a/cookie_manager/cookie_manager.py
+++ b/cookie_manager/cookie_manager.py
@@ -74,7 +74,8 @@ class CookieManager:
         :param signed_cookie: Signed cookie payload, containing a ``key_id`` that matches a key in ``self._keys``
         :return: Unsigned, trusted cookie as an object
         """
-        key = self._extract_key_id(signed_cookie=signed_cookie)
+        key_id = self._extract_key_id(signed_cookie=signed_cookie)
+        key = self._keys[key_id]
         return self._decode_verify_cookie(cookie=signed_cookie, verify_key=key)
 
     def _override_config(self, override_config: dict) -> dict:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="cookie-manager",
-    version="1.0.0",
+    version="1.0.1",
     author="ScholarPack",
     author_email="dev@scholarpack.com",
     description="Signed cookie manager for communication between multiple trusted services.",

--- a/tests/test_cookie_manager.py
+++ b/tests/test_cookie_manager.py
@@ -15,6 +15,18 @@ class TestCookieManager:
         self.cookie_manager = CookieManager(keys={"A": "A"}, exceptions=exceptions)
 
     @freeze_time("2019-12-06")
+    def test_verify_positive(self):
+        cookie_value = json.dumps({"A": "B", "key_id": "A"})
+
+        signed_cookie = (
+            TimestampSigner(secret_key="A").sign(cookie_value).decode("utf8")
+        )
+
+        unsigned_cookie = self.cookie_manager.verify(signed_cookie=signed_cookie)
+
+        assert unsigned_cookie == json.loads(cookie_value)
+
+    @freeze_time("2019-12-06")
     def test_decode_verify_positive(self):
         cookie_value = json.dumps({"A": "B"})
 


### PR DESCRIPTION
Fixed bug (and wrote test) whereby private decoding function was using `key_id` instead of the verifying key. 