### PR TITLE
Fixed the verify function to raise Error when a key_id was not present in the keys dict

### DIFF
--- a/cookie_manager/cookie_manager.py
+++ b/cookie_manager/cookie_manager.py
@@ -75,7 +75,12 @@ class CookieManager:
         :return: Unsigned, trusted cookie as an object
         """
         key_id = self._extract_key_id(signed_cookie=signed_cookie)
-        key = self._keys[key_id]
+        try:
+            key = self._keys[key_id]
+        except KeyError:
+            self._logger.error(f"Bad lookup for verifying key_id: {key_id}")
+            raise self._exceptions.ServiceUnavailable
+
         return self._decode_verify_cookie(cookie=signed_cookie, verify_key=key)
 
     def _override_config(self, override_config: dict) -> dict:

--- a/tests/test_cookie_manager.py
+++ b/tests/test_cookie_manager.py
@@ -35,9 +35,7 @@ class TestCookieManager:
         )
 
         with pytest.raises(exceptions.ServiceUnavailable):
-            self.cookie_manager.verify(
-                signed_cookie=signed_cookie
-            )
+            self.cookie_manager.verify(signed_cookie=signed_cookie)
 
     @freeze_time("2019-12-06")
     def test_decode_verify_positive(self):

--- a/tests/test_cookie_manager.py
+++ b/tests/test_cookie_manager.py
@@ -35,7 +35,7 @@ class TestCookieManager:
         )
 
         with pytest.raises(exceptions.ServiceUnavailable):
-            unsigned_cookie = self.cookie_manager.verify(
+            self.cookie_manager.verify(
                 signed_cookie=signed_cookie
             )
 

--- a/tests/test_cookie_manager.py
+++ b/tests/test_cookie_manager.py
@@ -27,6 +27,19 @@ class TestCookieManager:
         assert unsigned_cookie == json.loads(cookie_value)
 
     @freeze_time("2019-12-06")
+    def test_verify_nonexistent_keyid(self):
+        cookie_value = json.dumps({"A": "B", "key_id": "C"})
+
+        signed_cookie = (
+            TimestampSigner(secret_key="A").sign(cookie_value).decode("utf8")
+        )
+
+        with pytest.raises(exceptions.ServiceUnavailable):
+            unsigned_cookie = self.cookie_manager.verify(
+                signed_cookie=signed_cookie
+            )
+
+    @freeze_time("2019-12-06")
     def test_decode_verify_positive(self):
         cookie_value = json.dumps({"A": "B"})
 


### PR DESCRIPTION
Issue #12

The verify function didn't handle a key_id not present in the keys dict: (line 78)
I fixed the function to raise error when a key_id was not present in the keys dict and added test code for it.
Thank you.